### PR TITLE
Update six import for compatibility with django 3.0

### DIFF
--- a/graphene_django/debug/sql/tracking.py
+++ b/graphene_django/debug/sql/tracking.py
@@ -4,8 +4,8 @@ from __future__ import absolute_import, unicode_literals
 import json
 from threading import local
 from time import time
+import six
 
-from django.utils import six
 from django.utils.encoding import force_text
 
 from .types import DjangoDebugSQL

--- a/graphene_django/settings.py
+++ b/graphene_django/settings.py
@@ -13,9 +13,9 @@ back to the defaults.
 """
 from __future__ import unicode_literals
 
+import six
 from django.conf import settings
 from django.test.signals import setting_changed
-from django.utils import six
 
 try:
     import importlib  # Available in Python 3.1+


### PR DESCRIPTION
`django.utils.six` was removed on Django 3.0. Using `import six` instead.

See [Django 3.0 release notes](https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis)

The BriteLines team wants to upgrade to Django 3.0 and needs this updated in order to do so.